### PR TITLE
disk collection browser updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ set(HEADERS
     include/diskbrowser/picsplitter.h
     include/diskbrowser/picpreview.h
     include/diskbrowser/picsourcetype.h
+    include/diskbrowser/diskbrowser.h
     include/createimagedialog.h
     include/diskeditdialog.h
     include/autoboot.h

--- a/include/diskbrowser/dbini.h
+++ b/include/diskbrowser/dbini.h
@@ -43,17 +43,9 @@ public:
     bool save();
 //  void clear();
 
+    bool isJson() { return false; }
+
 private:
     QSettings* _settings = nullptr;
-    bool _dirty = false;
-
-    QString  _appData;
-    QString  _diskPic;
-    QString  _bSidePic;
-    QString  _titleFont;
-    QString  _indexFont;
-    LabelPos _labelPos;
-    LabelPos _bSidePos;
-    DirMap   _dirMap;
 };
 #endif // DBSETTINGS_H

--- a/include/diskbrowser/dbjson.h
+++ b/include/diskbrowser/dbjson.h
@@ -44,6 +44,7 @@ public:
     void setIndex(const QString& index, const QString& folder, const QString& disk);
     void setSideB(bool sideB, const QString& folder, const QString& disk);
     DiskLabel getLabel(const QDir& dir, const QString& disk);
+    void setLabel(const DiskLabel& label, const QString& folder, const QString& disk);
 
     bool load();
     bool save();

--- a/include/diskbrowser/dbjson.h
+++ b/include/diskbrowser/dbjson.h
@@ -9,23 +9,25 @@
 #include "picsourcetype.h"
 #include "dbsettings.h"
 
-//  {
-//      "db": {
-//          "pic": "<filepath>",
-//          "title_pos": @Rect(x,y,w,h),
-//          "title_pos_b":
-//          "index_pos":
-//          "index_pos_b":
-//      },
-//      "<path>": {
-//          "pic": "<filepath>",    (path-wide preview)
-//          "diskname": {
-//              "title": "<title text>",
-//              "index": "<index text>",   (example: "01")
-//              "sideb":[true|false]
-//          }
-//      }
-//  }
+/*  JSON file format:
+{
+  "db": {
+      "pic": "<filepath>",
+      "title_pos": @Rect(x,y,w,h),
+      "title_pos_b":
+      "index_pos":
+      "index_pos_b":
+  },
+  "<path>": {
+      "pic": "<filepath>",    (path-wide preview)
+      "diskname": {
+          "title": "<title text>",
+          "index": "<index text>",   (example: "01")
+          "sideb":[true|false]
+      }
+  }
+}
+*/
 
 class DbJson : public DbSettings
 {
@@ -47,18 +49,12 @@ public:
     bool save();
 //  void clear();
 
+    bool isJson() { return true; }
+
 private:
     QJsonDocument _jsDoc;
     QString       _fileName;
     QDir          _dataDir;
-
-    bool _dirty = false;
-
-    QString  _diskPic;
-    QString  _bSidePic;
-    LabelPos _labelPos;
-    LabelPos _bSidePos;
-    DirMap   _dirMap;
 
     QString checkCopyPic(const QString& name);
     QString makeFullPath(const QString& name);

--- a/include/diskbrowser/dbsettings.h
+++ b/include/diskbrowser/dbsettings.h
@@ -74,6 +74,11 @@ public:
     void clone(DbSettings& other);
     virtual bool isJson() = 0;
 
+    DirMap& getDirMap() { return _dirMap; }
+    QStringList getDirs() { return _dirMap.keys(); }
+    QString getDirPic(const QString& dir) { return _dirMap[dir].pic; }
+    QStringList getDisks(const QString& dir) { return _dirMap[dir].map.keys(); }
+
 protected:
     bool _dirty = false;
 

--- a/include/diskbrowser/dbsettings.h
+++ b/include/diskbrowser/dbsettings.h
@@ -72,7 +72,8 @@ public:
 
     bool isEmpty();
     void clone(DbSettings& other);
-    virtual bool isJson() = 0;
+    void merge(DbSettings& other);
+    virtual bool isJson() = 0;          // TBD omit (not used)
 
     DirMap& getDirMap() { return _dirMap; }
     QStringList getDirs() { return _dirMap.keys(); }

--- a/include/diskbrowser/dbsettings.h
+++ b/include/diskbrowser/dbsettings.h
@@ -45,6 +45,8 @@ struct LabelPos
 {
     QRect title;
     QRect index;
+
+    bool isEmpty() { return title.isEmpty() && index.isEmpty(); }
 };
 
 
@@ -68,14 +70,20 @@ public:
     virtual bool save()  = 0;
 //  virtual void clear() = 0;
 
+    bool isEmpty();
+    void clone(DbSettings& other);
+    virtual bool isJson() = 0;
+
 protected:
     bool _dirty = false;
 
     QString  _appData;
     QString  _diskPic;
-    QString  _bSidePic;
-    LabelPos _labelPos;
-    LabelPos _bSidePos;
+    QString  _bSidePic; // used?
+//  LabelPos _labelPos; not used
+//  LabelPos _bSidePos; not used
+    QString  _titleFont;
+    QString  _indexFont;
     DirMap   _dirMap;
 };
 

--- a/include/diskbrowser/diskbrowser.h
+++ b/include/diskbrowser/diskbrowser.h
@@ -1,0 +1,10 @@
+#ifndef DISKBROWSER_H
+#define DISKBROWSER_H
+
+#include "diskbrowser/picsourcetype.h"
+#include "diskbrowser/picpreview.h"
+#include "diskbrowser/dbsettings.h"
+#include "diskbrowser/dbini.h"
+#include "diskbrowser/dbjson.h"
+
+#endif // DISKBROWSER_H

--- a/include/diskbrowser/diskbrowserdlg.h
+++ b/include/diskbrowser/diskbrowserdlg.h
@@ -80,7 +80,6 @@ private:
     QString _diskFileName;
     QString _diskFullName;
     PicSourceType _picSource  = PicSource_none;
-    DbSettings*   _dbSettings = nullptr;
 
     void actionSetPic();
     void actionSetDirPic();

--- a/include/diskbrowser/diskbrowserdlg.h
+++ b/include/diskbrowser/diskbrowserdlg.h
@@ -55,7 +55,6 @@ private:
     void setItemIsFolder(QTreeWidgetItem* item, bool isFolder = true);
     bool itemIsFolder(QTreeWidgetItem* item);
     void refreshFoldersCombobox();
-    bool isDiskImage(const QString& name);
     void update();
     QString checkCopyPic(const QString& fname);
     QString findPicFile();
@@ -63,7 +62,6 @@ private:
     QString getMostRecentFolder();
     QString getMostRecentDisk();
     QString getRecentDisk(QString folder);
-    QString getParentDir(QString fileFolder);
     QString browseForPic(const QString& start, const QString& action);
     QString diskIndex(const QString& folder, const QString& disk);
     DiskLabel parsePicLabel(const QString& diskName = QString());

--- a/include/diskbrowser/diskbrowserdlg.h
+++ b/include/diskbrowser/diskbrowserdlg.h
@@ -14,9 +14,23 @@
 #include "dbsettings.h"
 #include "picsourcetype.h"
 
+
 namespace Ui {
 class DiskBrowserDlg;
 }
+
+
+class DbItem : public QTreeWidgetItem
+{
+public:
+    DbItem(QTreeWidget* parent) : QTreeWidgetItem(parent) {}
+    bool isFolder() const { return data(0, Qt::UserRole).toBool(); }
+    void setFolder(bool folder = true) { setData(0, Qt::UserRole, folder); }
+
+private:
+    bool operator<(const QTreeWidgetItem& other) const override;
+    bool compNumberVal(const QString& index, const QString& other, bool& comp) const;
+};
 
 
 class DiskBrowserDlg : public QDialog
@@ -31,7 +45,6 @@ public:
     int getVertSplitPos();
     void setHorzSplitPos(int pos);
     void setVertSplitPos(int pos);
-    DiskLabel parsePicLabel();
 
 protected:
     void showEvent(QShowEvent *event) override;
@@ -52,6 +65,8 @@ private:
     QString getRecentDisk(QString folder);
     QString getParentDir(QString fileFolder);
     QString browseForPic(const QString& start, const QString& action);
+    QString diskIndex(const QString& folder, const QString& disk);
+    DiskLabel parsePicLabel(const QString& diskName = QString());
 
     const QString FLOPPY_INDEXED_PNG  {":/icons/other-icons/floppy_front.png"};
     const QString FLOPPY_BACKSIDE_PNG {":/icons/other-icons/floppy_back.png"};

--- a/include/diskbrowser/folderdisks.h
+++ b/include/diskbrowser/folderdisks.h
@@ -54,8 +54,6 @@ private:
     QDir dir;
     QStringList dirList;
     QStringList diskList;
-    QString          _defaultPic;
-    QList<FloppyArt> _diskArt;
 };
 
 #endif // FOLDERDISKS_H

--- a/include/diskbrowser/picsourcetype.h
+++ b/include/diskbrowser/picsourcetype.h
@@ -3,6 +3,7 @@
 
 enum DbDataSource
 {
+    DbData_none = 0,
     DbData_appSettings,
     DbData_subDirJson,
     DbData_appFolderJson

--- a/include/diskbrowser/picsourcetype.h
+++ b/include/diskbrowser/picsourcetype.h
@@ -4,7 +4,7 @@
 enum DbDataSource
 {
     DbData_appSettings,
-    DbData_subDir,
+    DbData_subDirJson,
     DbData_appFolderJson
 };
 

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -55,6 +55,7 @@ public:
   QString g_sessionFilePath;
   QString g_mainWindowTitle;
   void doLogMessage(int type, const QString &msg);
+  bool checkChangeDbSource(DbDataSource dbSourceNew);
   static void logMessageOutput(QtMsgType type, const QMessageLogContext &context, const QString &msg);
   static MainWindow *instance() { return sInstance; }
 

--- a/include/miscutils.h
+++ b/include/miscutils.h
@@ -81,6 +81,11 @@ public:
   }
 };
 
+namespace DbUtils
+{
 QStringList toStringList(const QList<QByteArray>& list);
+QString getParentDir(const QString& fileFolder);
+QString removePrefix(const QString& prefix, const QString& name);
+}
 
 #endif// MISCUTILS_H

--- a/include/optionsdialog.h
+++ b/include/optionsdialog.h
@@ -32,6 +32,7 @@ public:
 protected:
   void changeEvent(QEvent *e) override;
   void showEvent(QShowEvent *e) override;
+  void closeEvent(QCloseEvent *e) override;
 
 private:
   Ui::OptionsDialog *m_ui;
@@ -40,9 +41,9 @@ private:
           *itemFirmware810Path, *itemFirmware1050Path, *itemFirmwareEmulation, *itemTraceOptions, *itemDiskImages;
 
   void selectFirmware(QLineEdit *edit, QString title, QString filters);
-
   void connectSignals();
   void setupSettings();
+  void setHorzSplitPos(int pos);
 
 private slots:
   void serialPortChanged(int index);
@@ -51,6 +52,7 @@ private slots:
   void sectionClicked(QTreeWidgetItem *item, int column);
   void currentSectionChanged(QTreeWidgetItem *current, QTreeWidgetItem *previous);
   void saveSettings();
+  void onClosed();
   void useCustomBaudToggled(bool checked);
   void appDataDirToggled();
   void diskSubDirToggled();

--- a/include/respeqtsettings.h
+++ b/include/respeqtsettings.h
@@ -300,7 +300,7 @@ public:
 
   // Disk Collection browser options page
   DbDataSource dbDataSource();
-  void setDbDataSource(DbDataSource dbSource);
+  void setDbDataSource(DbDataSource newDbSource);
   void setDbFileNames(bool useFileNames, bool favorJson = false);
   bool dbFavorJson();
   bool dbUseFileNames();

--- a/include/respeqtsettings.h
+++ b/include/respeqtsettings.h
@@ -146,6 +146,9 @@ public:
   bool minimizeToTray();
   void setMinimizeToTray(bool tray);
 
+  void setOptionsDlgSplitPos(int pos);
+  int  optionsDialogSplitPos();
+
   // Save window positions and sizes option //
   bool saveWindowsPos();
   void setSaveWindowsPos(bool saveMwp);
@@ -212,6 +215,7 @@ public:
   // save/restore top-level widget geometry
   bool saveWidgetGeometry(QWidget* widget, const QString& name = QString());
   bool restoreWidgetGeometry(QWidget* widget, const QString& name = QString(), const QRect& defRect = QRect());
+  bool windowPosSaved(QWidget* widget, const QString& name = QString());
 
   // Printer Spy Mode
   bool isPrinterSpyMode();

--- a/include/respeqtsettings.h
+++ b/include/respeqtsettings.h
@@ -311,6 +311,11 @@ public:
   QString appDataFolder();
   void setAppFolderDir(const QString& appDataDir);
 
+  // Disk Collection Browser artwork settings -
+  // These settings are kept seperately from above application global settings
+  // when dbDataSource is JSON (DbData_subDirJson and DbData_appFolderJson).
+  static const std::unique_ptr<DbSettings>& dbSettings();
+
   bool debugMenuVisible() const;
   void setDebugMenuVisible(bool menuVisible);
 
@@ -328,8 +333,10 @@ private:
 
 public:
   QSettings *mSettings;
+
 private:
-  //void writeRecentImageSettings();
+  static std::unique_ptr<DbSettings> sDbSettings;
+
   void writeRecentBrowserFolders(const QStringList& folders);
   const int maxRecentBrowserFolders = 10;
 

--- a/include/respeqtsettings.h
+++ b/include/respeqtsettings.h
@@ -284,9 +284,11 @@ public:
 
   // Disk Collection Browser
   QString mostRecentBrowserFolder();
-  QStringList recentBrowserFolders();
+  QStringList recentBrowserFolders();   // raw from QSettings map
+  QStringList buildBrowserFolders();    // remove selected disk names from paths and validates exists
   void setMostRecentBrowserFolder(const QString& name);
   void delMostRecentBrowserFolder(const QString& name);
+  bool isDiskImage(const QString& name);
   bool showDiskBrowser();
   void setShowDiskBrowser(bool show = true);
   int  diskBrowserHorzSplitPos();
@@ -338,7 +340,7 @@ private:
   static std::unique_ptr<DbSettings> sDbSettings;
 
   void writeRecentBrowserFolders(const QStringList& folders);
-  const int maxRecentBrowserFolders = 10;
+//  const int maxRecentBrowserFolders = 10;
 
   bool mIsFirstTime;
 

--- a/sources.pri
+++ b/sources.pri
@@ -79,7 +79,6 @@ SOURCES += \
     src/diskbrowser/diskbrowserdlg.cpp
 
 HEADERS += \
-    $$PWD/include/diskbrowser/diskbrowser.h \
     include/mainwindow.h \
     include/printers/outputwindow.h \
     include/printers/rawoutput.h \
@@ -148,6 +147,7 @@ HEADERS += \
     include/diskbrowser/dbsettings.h \
     include/diskbrowser/dbjson.h \
     include/diskbrowser/dbini.h \
+    include/diskbrowser/diskbrowser.h \
     include/diskbrowser/diskbrowserdlg.h
 
 FORMS += \

--- a/sources.pri
+++ b/sources.pri
@@ -79,6 +79,7 @@ SOURCES += \
     src/diskbrowser/diskbrowserdlg.cpp
 
 HEADERS += \
+    $$PWD/include/diskbrowser/diskbrowser.h \
     include/mainwindow.h \
     include/printers/outputwindow.h \
     include/printers/rawoutput.h \

--- a/src/diskbrowser/dbini.cpp
+++ b/src/diskbrowser/dbini.cpp
@@ -10,8 +10,9 @@
 DbIni::DbIni()
 {
     _appData  = RespeqtSettings::instance()->appDataFolder();
-    _settings = RespeqtSettings::instance()->mSettings;
-
+    _settings = RespeqtSettings::instance()->mSettings;         // did I make mSettings public for this? (probably bad)
+                                                                // _settings was also once optionally used for seperate ini file.
+                                                                // This is now only a ref to the app QSetting instance (TBD: fix).
     DbIni::load();
 }
 

--- a/src/diskbrowser/dbini.cpp
+++ b/src/diskbrowser/dbini.cpp
@@ -32,16 +32,16 @@ void DbIni::setPicture(const QString& pic, const QString& dir, const QString& di
     bool isGlobal = (dir.isEmpty() && disk.isEmpty());     // program global pic?
     bool isDirPic = (!dir.isEmpty() && disk.isEmpty());
     bool isDiskPic = (!dir.isEmpty() && !disk.isEmpty());
-    QString escDir = QDir::fromNativeSeparators(dir).replace('/','@');
+    QString lnxDir = QDir::fromNativeSeparators(dir);
 
     if (isGlobal)
         _diskPic = pic;
 
     if (isDirPic)
-        _dirMap[escDir].pic = pic;
+        _dirMap[lnxDir].pic = pic;
 
     if (isDiskPic)
-        _dirMap[escDir].map[disk].pic = pic;
+        _dirMap[lnxDir].map[disk].pic = pic;
 
     _dirty = true;
 }
@@ -49,8 +49,8 @@ void DbIni::setPicture(const QString& pic, const QString& dir, const QString& di
 QString DbIni::getPicture(const QDir& dir, const QString& disk, PicSourceType& picSource)
 {
     QString dirStr  = dir.absolutePath();
-    QString escDir  = QDir::fromNativeSeparators(dirStr).replace('/','@');
-    auto    dirInfo = _dirMap[escDir];
+    QString lnxDir  = QDir::fromNativeSeparators(dirStr);
+    auto    dirInfo = _dirMap[lnxDir];
 
     QString pic;
     picSource = PicSource_none;
@@ -76,30 +76,30 @@ QString DbIni::getPicture(const QDir& dir, const QString& disk, PicSourceType& p
 
 void DbIni::setTitle(const QString& title, const QString& folder, const QString& disk)
 {
-    QString escDir = QDir::fromNativeSeparators(folder).replace('/','@');
-    _dirMap[escDir].map[disk].label.title = title;
+    QString lnxDir = QDir::fromNativeSeparators(folder);
+    _dirMap[lnxDir].map[disk].label.title = title;
     _dirty = true;
 }
 
 void DbIni::setIndex(const QString& index, const QString& folder, const QString& disk)
 {
-    QString escDir = QDir::fromNativeSeparators(folder).replace('/','@');
-    _dirMap[escDir].map[disk].label.index = index;
+    QString lnxDir = QDir::fromNativeSeparators(folder);
+    _dirMap[lnxDir].map[disk].label.index = index;
     _dirty = true;
 }
 
 void DbIni::setSideB(bool sideB, const QString& folder, const QString& disk)
 {
-    QString escDir = QDir::fromNativeSeparators(folder).replace('/','@');
-    _dirMap[escDir].map[disk].label.sideB = sideB;
+    QString lnxDir = QDir::fromNativeSeparators(folder);
+    _dirMap[lnxDir].map[disk].label.sideB = sideB;
     _dirty = true;
 }
 
 DiskLabel DbIni::getLabel(const QDir& dir, const QString& disk)
 {
     QString folder = dir.absolutePath();
-    QString escDir = QDir::fromNativeSeparators(folder).replace('/','@');
-    return _dirMap[escDir].map[disk].label;
+    QString lnxDir = QDir::fromNativeSeparators(folder);
+    return _dirMap[lnxDir].map[disk].label;
 }
 
 bool DbIni::load()
@@ -131,7 +131,7 @@ bool DbIni::load()
             _settings->beginGroup(childGroup);
 
             if (_settings->contains("pic"))
-                dirInfo.map[childGroup].pic = _settings->value("pic").toString();
+                dirInfo.map[childGroup].pic = _settings->value("pic").toString().replace('@','/');
             if (_settings->contains("title"))
                 dirInfo.map[childGroup].label.title = _settings->value("title").toString();
             if (_settings->contains("index"))
@@ -141,7 +141,7 @@ bool DbIni::load()
 
             _settings->endGroup();
         }
-        _dirMap[group] = dirInfo;
+        _dirMap[group.replace('@','/')] = dirInfo;
 
         _settings->endGroup();
     }
@@ -161,29 +161,30 @@ bool DbIni::save()
     _settings->remove("");
 
     if (!_diskPic.isEmpty())
-        _settings->setValue("pic", _diskPic);
+        _settings->setValue("pic", _diskPic.replace('/','@'));
 
     for (auto it = _dirMap.begin(); it != _dirMap.end(); ++it)
     {
         DirInfo& dirInfo = it.value();
         QString  escDir  = it.key();
+        escDir.replace('/','@');
 
         _settings->beginGroup(escDir);
 
         if (!dirInfo.pic.isEmpty())
-            _settings->setValue("pic",dirInfo.pic);
+            _settings->setValue("pic", dirInfo.pic.replace('/','@'));
 
         for (auto it = dirInfo.map.begin(); it != dirInfo.map.end(); ++it)
         {
-            const FloppyArt& art = it.value();
-            const QString group  = it.key();
+            FloppyArt art = it.value();
+            QString group = it.key();
 
             if (art.isEmpty())
                 continue;
 
             _settings->beginGroup(group);
             if (!art.pic.isEmpty())
-                _settings->setValue("pic", art.pic);
+                _settings->setValue("pic", art.pic.replace('/','@'));
             if (!art.label.title.isEmpty())
                 _settings->setValue("title", art.label.title);
             if (!art.label.index.isEmpty())

--- a/src/diskbrowser/dbini.cpp
+++ b/src/diskbrowser/dbini.cpp
@@ -18,7 +18,8 @@ DbIni::DbIni()
 
 DbIni::~DbIni()
 {
-    DbIni::save();
+    if (_dirty)
+        DbIni::save();
 }
 
 void DbIni::setDataDir(const QString &dir)
@@ -124,7 +125,7 @@ bool DbIni::load()
         _settings->beginGroup(group);
 
         if (_settings->contains("pic"))
-            dirInfo.pic = _settings->value("pic").toString();
+            dirInfo.pic = _settings->value("pic").toString().replace('@','/');
 
         foreach (const QString& childGroup, _settings->childGroups())
         {

--- a/src/diskbrowser/dbjson.cpp
+++ b/src/diskbrowser/dbjson.cpp
@@ -12,7 +12,8 @@ DbJson::DbJson()
 
 DbJson::~DbJson()
 {
-    DbJson::save();
+    if (_dirty)
+        DbJson::save();
 }
 
 void DbJson::setDataDir(const QString& dir)

--- a/src/diskbrowser/dbjson.cpp
+++ b/src/diskbrowser/dbjson.cpp
@@ -164,7 +164,7 @@ QString DbJson::checkCopyPic(const QString& name)
     // remove the path name if it's not needed
     // (allows collection/folder to be moved/copied)
 
-    if ((RespeqtSettings::instance()->dbDataSource() == DbData_subDir)
+    if ((RespeqtSettings::instance()->dbDataSource() == DbData_subDirJson)
          && name.startsWith(_dataDir.absolutePath()))
         return name.right(name.count() - _dataDir.absolutePath().count() - 1);
 
@@ -199,7 +199,7 @@ bool DbJson::save()
 
     auto it = _dirMap.begin();  // set iterator to the first disk collection folder
 
-    bool useSubDir = (RespeqtSettings::instance()->dbDataSource() == DbData_subDir);
+    bool useSubDir = (RespeqtSettings::instance()->dbDataSource() == DbData_subDirJson);
     if (useSubDir)
     {
         QDir upDir(_dataDir);               // disk collection dir will be the parent

--- a/src/diskbrowser/dbjson.cpp
+++ b/src/diskbrowser/dbjson.cpp
@@ -27,6 +27,9 @@ void DbJson::setDataDir(const QString& dir)
 
 void DbJson::setPicture(const QString& pic, const QString& dir, const QString& disk)
 {
+    if (pic.isEmpty())
+        return;
+
     bool isGlobal = (dir.isEmpty() && disk.isEmpty());     // program global pic?
     bool isDirPic = (!dir.isEmpty() && disk.isEmpty());
     bool isDiskPic = (!dir.isEmpty() && !disk.isEmpty());
@@ -41,6 +44,13 @@ void DbJson::setPicture(const QString& pic, const QString& dir, const QString& d
     if (isDiskPic)
         _dirMap[lnxDir].map[disk].pic = pic;
 
+    _dirty = true;
+}
+
+void DbJson::setLabel(const DiskLabel& label, const QString& dir, const QString& disk)
+{
+    QString lnxDir = QDir::fromNativeSeparators(dir);
+    _dirMap[lnxDir].map[disk].label = label;
     _dirty = true;
 }
 
@@ -164,9 +174,8 @@ QString DbJson::checkCopyPic(const QString& name)
     // remove the path name if it's not needed
     // (allows collection/folder to be moved/copied)
 
-    if ((RespeqtSettings::instance()->dbDataSource() == DbData_subDirJson)
-         && name.startsWith(_dataDir.absolutePath()))
-        return name.right(name.count() - _dataDir.absolutePath().count() - 1);
+    if (RespeqtSettings::instance()->dbDataSource() == DbData_subDirJson)
+        return DbUtils::removePrefix(_dataDir.absolutePath(), name);
 
     return name;
 }

--- a/src/diskbrowser/dbsettings.cpp
+++ b/src/diskbrowser/dbsettings.cpp
@@ -12,3 +12,19 @@ DbSettings::DbSettings()
 DbSettings::~DbSettings()
 {
 }
+
+bool DbSettings::isEmpty()
+{
+    if (_dirty)
+        return false;
+
+    return //_appData.isEmpty() && c/o any settings cached in the main settings
+            // TBD: more than this plus don't c/o above
+           _dirMap.isEmpty();
+}
+
+void DbSettings::clone(DbSettings& other)
+{
+    _dirMap = other._dirMap;
+//    _diskPic = other._diskPic;   TBD: more than this (?)
+}

--- a/src/diskbrowser/dbsettings.cpp
+++ b/src/diskbrowser/dbsettings.cpp
@@ -26,5 +26,12 @@ bool DbSettings::isEmpty()
 void DbSettings::clone(DbSettings& other)
 {
     _dirMap = other._dirMap;
-//    _diskPic = other._diskPic;   TBD: more than this (?)
+    _diskPic = other._diskPic;   // TBD: more than this (?) ...hang on, is this used?
+    _dirty = true;
+}
+
+void DbSettings::merge(DbSettings& other)
+{
+    _dirMap.insert(other.getDirMap());
+    _dirty = true;
 }

--- a/src/diskbrowser/diskbrowserdlg.cpp
+++ b/src/diskbrowser/diskbrowserdlg.cpp
@@ -175,7 +175,11 @@ void DiskBrowserDlg::onFolderChanged(QString folder)
 
     if (!disk.isEmpty() && disks.contains(disk))
     {
-        auto items = ui->treeDisks->findItems(disk, Qt::MatchExactly, 1);
+        QString col1text = disk;
+        auto index = diskIndex(folder, disk);
+        if (!index.isEmpty() && disk.startsWith(index))
+            col1text = disk.mid(index.length() + 1);
+        auto items = ui->treeDisks->findItems(col1text, Qt::MatchExactly, 1);
         QTreeWidgetItem* item = (items.length() > 0) ? items[0] : nullptr;
         ui->treeDisks->setCurrentItem(item);
     }

--- a/src/diskbrowser/diskbrowserdlg.cpp
+++ b/src/diskbrowser/diskbrowserdlg.cpp
@@ -34,6 +34,8 @@ DiskBrowserDlg::DiskBrowserDlg(SioWorkerPtr pSio, QWidget *parent)
     ui->setupUi(this);
 
     ui->treeDisks->setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);
+    ui->treeDisks->setSortingEnabled(true);
+    ui->treeDisks->sortByColumn(0,Qt::SortOrder::AscendingOrder);
 
     ui->splitTopDirBotPng->setOther(ui->splitLeftAtrRightDirPng);
     ui->splitLeftAtrRightDirPng->setOther(ui->splitTopDirBotPng);
@@ -69,7 +71,7 @@ void DiskBrowserDlg::clear()
 
     ui->treeDisks->blockSignals(true);
     ui->treeDisks->clear();
-    ui->treeDisks->setColumnCount(1);
+    ui->treeDisks->setColumnCount(2);
     ui->treeDisks->setHeaderHidden(true);
     ui->treeDisks->setRootIsDecorated(false);
     ui->treeDisks->blockSignals(false);
@@ -145,22 +147,27 @@ void DiskBrowserDlg::onFolderChanged(QString folder)
         if (subdir.startsWith('.') && (subdir != ".."))     // hide .folders on Windows
             continue;
 
-        auto item = new QTreeWidgetItem(ui->treeDisks);
-        auto icon = QIcon{":/icons/silk-icons/icons/folder_explore.png"};
-        item->setText(0, subdir);
-        item->setIcon(0, icon);
-        setItemIsFolder(item, true);
+        auto item = new DbItem(ui->treeDisks);
+        auto icon = QIcon{":/icons/silk-icons/icons/folder.png"};
+        item->setIcon(1, icon);
+        item->setText(1, subdir);
+        item->setFolder(true);
     }
 
     // fill in all disk image files
     auto disks = _folderDisks.disks();
     foreach (const QString &disk, disks)
     {
-        auto item = new QTreeWidgetItem(ui->treeDisks);
-        auto icon = QIcon{":/icons/other-icons/floppy.png"};
-        item->setText(0, disk);
-        item->setIcon(0, icon);
-        setItemIsFolder(item, false);
+        auto index = diskIndex(folder, disk);
+        auto item = new DbItem(ui->treeDisks);
+        item->setText(0, index);
+        if (!index.isEmpty() && disk.startsWith(index))
+        {
+            item->setText(1, disk.mid(index.length() + 1));
+            item->setData(1, Qt::UserRole, index);
+        }
+        else
+            item->setText(1, disk);
     }
 
     if (disk.isEmpty())
@@ -174,10 +181,12 @@ void DiskBrowserDlg::onFolderChanged(QString folder)
 
     if (!disk.isEmpty() && disks.contains(disk))
     {
-        auto items = ui->treeDisks->findItems(disk, Qt::MatchExactly);
-        QTreeWidgetItem *item = (items.length() > 0) ? items[0] : nullptr;
+        auto items = ui->treeDisks->findItems(disk, Qt::MatchExactly, 1);
+        QTreeWidgetItem* item = (items.length() > 0) ? items[0] : nullptr;
         ui->treeDisks->setCurrentItem(item);
     }
+
+    ui->treeDisks->resizeColumnToContents(0);
 }
 
 void DiskBrowserDlg::refreshFoldersCombobox()
@@ -238,7 +247,10 @@ void DiskBrowserDlg::update()
         return;
     }
 
-    QString diskName = currentItem->text(0);
+    QString diskName = currentItem->text(1);
+    QString strIndex = currentItem->data(1, Qt::UserRole).toString();
+    if (!strIndex.isEmpty())
+        diskName = strIndex + "." + diskName;
     QString pathName = ui->cboFolderPath->currentText();
     QString fullName = pathName + QString("/") + diskName;
     QFileInfo fiDisk = QFileInfo(fullName);
@@ -340,7 +352,7 @@ void DiskBrowserDlg::update()
         if (!_picInfo.pic.isEmpty())
         {
             _picSource = PicSource_floppy;
-            if (_picInfo.label.isEmpty())
+            if (_picInfo.label.title.isEmpty())
                 _picInfo.label.title = _diskTitle;
             ui->picPreview->setLabel(_picInfo.label);
         }
@@ -432,7 +444,7 @@ void DiskBrowserDlg::setVertSplitPos(int pos)
 
 void DiskBrowserDlg::itemDoubleClicked(QTreeWidgetItem *item, int)
 {
-    QString text = item->text(0);
+    QString text = item->text(1);
     auto path = ui->cboFolderPath->currentText();
 
     if (text == "..")
@@ -449,14 +461,13 @@ void DiskBrowserDlg::itemDoubleClicked(QTreeWidgetItem *item, int)
     }
 }
 
-void DiskBrowserDlg::setItemIsFolder(QTreeWidgetItem *item, bool isFolder)
-{
-    item->setData(0, Qt::UserRole, isFolder);
-}
-
 bool DiskBrowserDlg::itemIsFolder(QTreeWidgetItem *item)
 {
-    return item->data(0, Qt::UserRole).toBool();
+    DbItem* dbItem = dynamic_cast<DbItem*>(item);
+    if (dbItem && dbItem->isFolder())
+        return true;
+
+    return false;
 }
 
 void DiskBrowserDlg::closeEvent(QCloseEvent *event)
@@ -492,16 +503,18 @@ void DiskBrowserDlg::showEvent(QShowEvent *event)
         update();
 }
 
-DiskLabel DiskBrowserDlg::parsePicLabel()
+DiskLabel DiskBrowserDlg::parsePicLabel(const QString& diskName)
 {
+    QString baseName = diskName;
+
+    if (baseName.isEmpty())
+    {
+        auto fileInfo = QFileInfo {_diskFullName};
+        Q_ASSERT(fileInfo.exists());                // validated prior to this call
+        baseName = fileInfo.completeBaseName();
+    }
+
     DiskLabel label;
-
-    auto fileInfo = QFileInfo {_diskFullName};
-
-    Q_ASSERT(fileInfo.exists());    // validated prior to this call
-
-    QString baseName = fileInfo.completeBaseName();
-
     static QRegularExpression re("(^\\d+)([b|B]?)(\\.?)(.*)");
     auto rem = re.match(baseName);
 
@@ -609,8 +622,11 @@ void DiskBrowserDlg::popupMenuReq(const QPoint& pos)
     QMenu menu;
     menu.addAction(QIcon(":/icons/silk-icons/icons/image.png"), "Set Default Preview...", this, &DiskBrowserDlg::actionSetDefault);
     menu.addAction(QIcon(":/icons/silk-icons/icons/folder_image.png"), "Set Folder Preview Pic...", this, &DiskBrowserDlg::actionSetDirPic);
-    menu.addAction(QIcon(":/icons/silk-icons/icons/image_add.png"), "Set Disk Preview Pic...", this, &DiskBrowserDlg::actionSetPic);
-    menu.addAction(QIcon(":/icons/silk-icons/icons/image_delete.png"), "Clear Preview", this, &DiskBrowserDlg::actionClearPic);
+    if (_picSource != PicSource_none)
+    {
+        menu.addAction(QIcon(":/icons/silk-icons/icons/image_add.png"), "Set Disk Preview Pic...", this, &DiskBrowserDlg::actionSetPic);
+        menu.addAction(QIcon(":/icons/silk-icons/icons/image_delete.png"), "Clear Preview", this, &DiskBrowserDlg::actionClearPic);
+    }
     if (_picSource == PicSource_floppy)
     {
         menu.addSeparator();
@@ -651,6 +667,9 @@ void DiskBrowserDlg::indexChanged(QString index)
 {
     _picInfo.label.index = index;
     _dbSettings->setIndex(index, _currentDir, _diskFileName);
+    ui->treeDisks->currentItem()->setText(0, index);
+    ui->treeDisks->resizeColumnToContents(0);
+    ui->treeDisks->sortByColumn(0, Qt::AscendingOrder); // BUG in custom sort (shouldn't need this!)
 }
 
 QString DiskBrowserDlg::browseForPic(const QString& start, const QString& action)
@@ -800,4 +819,78 @@ void DiskBrowserDlg::actionClearPic()
     }
 
     update();
+}
+
+QString DiskBrowserDlg::diskIndex(const QString& folder, const QString& disk)
+{
+    QString index;
+
+    if (RespeqtSettings::instance()->dbUseFileNames())
+    {
+        auto label = parsePicLabel(disk);
+        index = label.index;
+        if (label.sideB)
+            index += 'b';
+    }
+    if (index.isEmpty() || RespeqtSettings::instance()->dbFavorJson())
+    {
+        auto label = _dbSettings->getLabel(folder, disk);
+        if (index.isEmpty() || !label.isEmpty())
+            index = label.index;
+    }
+
+    return index;
+}
+
+
+// DbItem class - mostly just so I can sort the TreeDisks by the index column
+//
+bool DbItem::operator<(const QTreeWidgetItem& other) const
+{
+    const DbItem& dbOther = dynamic_cast<const DbItem&>(other);
+    if (!isFolder() && dbOther.isFolder())
+        return false;
+
+    bool comp = QTreeWidgetItem::operator<(other);
+
+    if (isFolder() && dbOther.isFolder())
+        return comp;
+
+    if (text(0).isEmpty() && other.text(0).isEmpty())
+        return comp;
+
+    if (compNumberVal(text(0), other.text(0), comp))
+        return comp;
+
+    if (text(0).isEmpty() || other.text(0).isEmpty())
+        return !comp;
+
+    return comp;
+}
+
+bool DbItem::compNumberVal(const QString& index, const QString& other, bool& comp) const
+{
+    static QRegularExpression re("^(\\d+)([b|B]?)$");
+    auto remIndex = re.match(index);
+    auto remOther = re.match(other);
+    bool bothNums = remIndex.hasMatch() && remOther.hasMatch();
+
+    if (bothNums)
+    {
+        int nIndex = remIndex.captured(1).toInt();
+        int nOther = remOther.captured(1).toInt();
+
+        if (nIndex == nOther)
+        {
+            bool bIndex = !remIndex.captured(2).isEmpty();
+            bool bOther = !remOther.captured(2).isEmpty();
+
+            comp = !bIndex && bOther;
+        }
+        else
+        {
+            comp = nIndex < nOther;
+        }
+    }
+    return bothNums;
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2065,3 +2065,29 @@ void MainWindow::restoreLayout()
             showLogWindowTriggered();
     }
 }
+
+bool MainWindow::checkChangeDbSource(DbDataSource dbSourceNew)
+{
+    DbDataSource dbSourceNow = RespeqtSettings::instance()->dbDataSource();
+    if (dbSourceNew == dbSourceNow)
+        return false;
+
+    auto &sDbSettings = RespeqtSettings::dbSettings();
+    if (!sDbSettings || sDbSettings->isEmpty())
+        return true;
+
+    if (!diskBrowserDlg)
+        return true;
+
+    if (diskBrowserDlg->isVisible())
+    {
+        QMessageBox::warning(diskBrowserDlg, tr("Data Format Conversion Required"),
+               tr("The Disk Collection Browser Window is currently open.\n"
+                  "To convert DCB data format, please close and try again."));
+        return false;
+    }
+
+    diskBrowserDlg->close();
+    diskBrowserDlg = nullptr;
+    return true;
+}

--- a/src/miscutils.cpp
+++ b/src/miscutils.cpp
@@ -208,6 +208,8 @@ bool GzFile::atEnd() const {
   return gzeof(mHandle);
 }
 
+namespace DbUtils
+{
 QStringList toStringList(const QList<QByteArray>& list)
 {
     QStringList strings;
@@ -219,4 +221,28 @@ QStringList toStringList(const QList<QByteArray>& list)
     }
 
     return strings;
+}
+
+QString getParentDir(const QString& fileFolder)
+{
+    QString linuxName = QDir::fromNativeSeparators(fileFolder);
+    bool wasNonNative = linuxName != fileFolder;
+
+    int lastSlash = linuxName.lastIndexOf('/');
+    if (lastSlash >= 0)
+        linuxName.truncate(lastSlash);
+
+    if (wasNonNative)
+        return QDir::toNativeSeparators(linuxName);
+
+    return linuxName;   // linux names ok on modern windows
+}
+
+QString removePrefix(const QString& prefix, const QString& name)
+{
+    if (name.startsWith(prefix))
+        return name.right(name.count() - prefix.count() - 1);
+
+    return name;
+}
 }

--- a/src/optionsdialog.cpp
+++ b/src/optionsdialog.cpp
@@ -119,7 +119,7 @@ void OptionsDialog::setupSettings() {
   case DbData_appFolderJson:
       m_ui->rb_dbset_app_data_dir->setChecked(true);
       break;
-  case DbData_subDir:
+  case DbData_subDirJson:
       m_ui->rb_dbset_subdir->setChecked(true);
       break;
   case DbData_appSettings: default:
@@ -475,7 +475,7 @@ void OptionsDialog::saveSettings() {
   }
   else if (m_ui->rb_dbset_subdir->isChecked())
   {
-      dbSource = DbData_subDir;
+      dbSource = DbData_subDirJson;
   }
   RespeqtSettings::instance()->setDbDataSource(dbSource);
   LabelFont titleFont

--- a/src/optionsdialog.cpp
+++ b/src/optionsdialog.cpp
@@ -635,6 +635,7 @@ void OptionsDialog::diskSubDirToggled()
     if (m_ui->rb_dbset_subdir->isChecked())
         m_ui->cb_copypics->setText(tr("Copy pics to .respeqt_db subdir"));
 }
+
 void OptionsDialog::appSettingsToggled()
 {
     if (m_ui->rb_dbset_appset_ini->isChecked())

--- a/src/optionsdialog.cpp
+++ b/src/optionsdialog.cpp
@@ -467,17 +467,23 @@ void OptionsDialog::saveSettings() {
   RespeqtSettings::instance()->setClearOnStatus(m_ui->clearOnStatus->isChecked());
   RespeqtSettings::instance()->setDbFileNames(m_ui->cb_filename->isChecked(), m_ui->cb_favor_json->isChecked());
   RespeqtSettings::instance()->setDbCopyPics(m_ui->cb_copypics->isChecked());
-  DbDataSource dbSource = DbData_appSettings;
+
+  DbDataSource dbSourceNew = DbData_appSettings;
   if (m_ui->rb_dbset_app_data_dir->isChecked())
   {
-      dbSource = DbData_appFolderJson;
-      RespeqtSettings::instance()->setAppFolderDir(m_ui->edt_appdata_dir->text());
+      dbSourceNew = DbData_appFolderJson;
+      RespeqtSettings::instance()->setAppFolderDir(m_ui->edt_appdata_dir->text());  // TBD: ok to just change this? What about db source conversion stuff below?
   }
   else if (m_ui->rb_dbset_subdir->isChecked())
   {
-      dbSource = DbData_subDirJson;
+      dbSourceNew = DbData_subDirJson;
   }
-  RespeqtSettings::instance()->setDbDataSource(dbSource);
+
+  if (MainWindow::instance()->checkChangeDbSource(dbSourceNew))
+  {
+    RespeqtSettings::instance()->setDbDataSource(dbSourceNew);
+  }
+
   LabelFont titleFont
   {
       m_ui->cb_title_font->currentFont().family(),

--- a/src/respeqtsettings.cpp
+++ b/src/respeqtsettings.cpp
@@ -13,7 +13,6 @@
 #include "respeqtsettings.h"
 #include "serialport.h"
 #include "diskbrowser/diskbrowser.h"
-#include "diskbrowser/dbjson.h"
 #include <QFileInfo>
 #include <memory>
 #include <QApplication>

--- a/src/respeqtsettings.cpp
+++ b/src/respeqtsettings.cpp
@@ -938,6 +938,14 @@ void RespeqtSettings::setDiskBrowserVertSplitPos(int pos) {
   mSettings->setValue("/DiskBrowserDlg/VertSplitPos", pos);
 }
 
+void RespeqtSettings::setOptionsDlgSplitPos(int pos) {
+  mSettings->setValue("/OptionsDialog/SplitterPos", pos);
+}
+
+int RespeqtSettings::optionsDialogSplitPos() {
+  return mSettings->value("/OptionsDialog/SplitterPos",-1).toInt();
+}
+
 bool RespeqtSettings::saveMainWinGeometry(QMainWindow* window, bool isMiniMode) {
   if (!window || !saveWindowsPos())
     return false;
@@ -985,6 +993,20 @@ bool RespeqtSettings::restoreWidgetGeometry(QWidget* widget, const QString& name
   }
 
   return true;
+}
+
+bool RespeqtSettings::windowPosSaved(QWidget* widget, const QString& name)
+{
+    if (widget == nullptr)
+        return false;
+
+    QString key = name.isEmpty() ? widget->objectName() : name;
+    if (key.isEmpty())
+        return false;
+
+    key += "/geometry";
+
+    return mSettings->contains(key);
 }
 
 void RespeqtSettings::setDbDataSource(DbDataSource newDbSource)

--- a/ui/diskbrowserdlg.ui
+++ b/ui/diskbrowserdlg.ui
@@ -62,12 +62,29 @@
         <verstretch>0</verstretch>
        </sizepolicy>
       </property>
+      <property name="sortingEnabled">
+       <bool>true</bool>
+      </property>
       <property name="headerHidden">
        <bool>true</bool>
       </property>
+      <property name="columnCount">
+       <number>2</number>
+      </property>
+      <attribute name="headerMinimumSectionSize">
+       <number>0</number>
+      </attribute>
+      <attribute name="headerDefaultSectionSize">
+       <number>30</number>
+      </attribute>
       <column>
        <property name="text">
         <string notr="true">1</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string notr="true">2</string>
        </property>
       </column>
      </widget>


### PR DESCRIPTION
The initial release of the Disk Collection Browser was not completely tested and lacked the ability to convert between artwork data sources. There's 3 schemes that involve persisting artwork data and one that uses file naming. The file naming scheme stands alone and can not be converted to/from the other 3 schemes. 

The 3 storage schemes are selected in the RespeQt options dialog under the Disk Collection Browser tab/page. These are the 3 radio buttons on the top of the page. The details on these options are described in the .rtf document found in the deployed app folder.

This commit allows the user to create a working definition of titles/labels and cover art then later select a different storage scheme in the options dialog.  When the new selection is saved, the sytem will automatically convert the persisted data from one to the other. 