### PR TITLE
Fix out-of-bounds access in Happy RAM initialization

### DIFF
--- a/src/diskimages/diskimage.cpp
+++ b/src/diskimages/diskimage.cpp
@@ -119,10 +119,15 @@ namespace DiskImages {
     if (m_board.isHappyEnabled()) {
       m_board.setChipOpen(false);
       if (m_board.m_happyRam.size() == 0) {
-        m_board.m_happyRam.reserve(6144);
-        for (unsigned int i = 0; i < 6144; i++) {
-          m_board.m_happyRam[i] = 0;
-        }
+// boeserwatz 05.01.25
+// QT-Meldungen kommen so nicht mehr und schneller mit fill
+        m_board.m_happyRam.resize(6144);
+        m_board.m_happyRam.fill(0);
+// reserve raus - Schleife auch
+//        m_board.m_happyRam.reserve(6144);
+//        for (unsigned int i = 0; i < 6144; i++) {
+//          m_board.m_happyRam[i] = 0;
+//        }
         m_board.m_happyRam[0] = 0x80;
         for (unsigned int i = 0; i < sizeof(HAPPY_INITIAL_SECTOR_LIST); i++) {
           m_board.m_happyRam[0x280 + i] = HAPPY_INITIAL_SECTOR_LIST[i];


### PR DESCRIPTION
This PR fixes an out-of-bounds access in the Happy drive
initialization code.

QByteArray::reserve() was used instead of resize(), causing
operator[] to access memory beyond the array size when
initializing the Happy RAM buffer. This resulted in repeated
Qt warnings and could lead to crashes, especially during
CHIP → HAPPY mode switching.

The fix initializes the QByteArray with the correct size.